### PR TITLE
fix: make coverage stats optional for report

### DIFF
--- a/modules/local/benchmark_report.nf
+++ b/modules/local/benchmark_report.nf
@@ -18,13 +18,14 @@ process BENCHMARK_REPORT {
     def template_arg = "--template ${report_template}"
     def css_arg = css.collect { "--css ${it}" }.join(" ")
     def js_arg = js.collect { "--js ${it}" }.join(" ")
+    def cov_arg = coverage_csv ? "--coverage-csv ${coverage_csv}" : ""
     """
     benchmark_report.py \\
         ${css_arg} \\
         ${js_arg} \\
         ${template_arg} \\
         --happy-csv ${happy_output} \\
-        --coverage-csv ${coverage_csv} \\
+        ${cov_arg} \\
         --snv-af-csv ${snv_af_csv} \\
         --output ${prefix}.benchmark_report.html
     """

--- a/subworkflows/reporting.nf
+++ b/subworkflows/reporting.nf
@@ -25,12 +25,12 @@ workflow REPORTING {
         .map { [[id: "all"], it] }
         .set { ch_happy_files }
 
-    coverage_stats
+    ch_coverage_files = coverage_stats
         .collectFile(newLine: false, keepHeader: true){ meta, json ->
             ["report_coverage_json_files.csv", "id,sample,genome,json\n${meta.id},${meta.sample},${meta.genome},${json}\n"]
         }
         .map { [[id: "all"], it] }
-        .set { ch_coverage_files }
+        .ifEmpty([[id: "all"], []])
 
     snv_af_comparison
         .collectFile(newLine: false, keepHeader: true){ meta, tsv ->
@@ -48,6 +48,8 @@ workflow REPORTING {
         "${projectDir}/assets/af_plots.js"
     ]).collect().set { ch_js }
     Channel.fromPath(["${projectDir}/assets/report_style.css"]).collect().set { ch_css }
+
+    ch_coverage_files.view({it -> "coverage: $it"})
 
     BENCHMARK_REPORT(
         ch_happy_files,


### PR DESCRIPTION
With no coverage stats, the report wouldn't be generated. This addresses the issue and effectively makes the coverage stats optional.